### PR TITLE
Add putObjectFile, calculate MD5 using stream; fixed onSendProgress

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -234,6 +234,7 @@ class Client {
     final Map<String, String> headers = {
       'content-md5': await EncryptUtil.md5FileStream(file.openRead()),
       'content-type': mime(fileKey) ?? "image/png",
+      'content-length': (await file.length()).toString(),
     };
     final String url = "https://$bucket.$endpoint/$fileKey";
     final HttpRequest request = HttpRequest(url, 'PUT', {}, headers);

--- a/lib/src/encrypt.dart
+++ b/lib/src/encrypt.dart
@@ -14,4 +14,9 @@ class EncryptUtil {
     final Digest digest = md5.convert(bytes);
     return base64.encode(digest.bytes);
   }
+
+  /// use md5 to encrypt the file stream
+  static Future<String> md5FileStream(Stream<List<int>> stream) async {
+    return base64.encode((await md5.bind(stream).first).bytes);
+  }
 }


### PR DESCRIPTION
使用流的方式计算MD5，不会导致UI卡顿，但速度会慢一些。
Header添加content-length，onSendProgress才会生效，putObject添加进度不会动，不清楚具体原因。