### PR TITLE
option add content type

### DIFF
--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -254,7 +254,7 @@ class Client {
     );
 
     final Map<String, dynamic> headers = {
-      'content-type': "application/octet-stream",
+      'content-type': option?.contentType ?? "application/octet-stream",
       'content-length': multipartFile.length,
       'x-oss-forbid-overwrite': option.forbidOverride,
       'x-oss-object-acl': option.acl,
@@ -294,7 +294,7 @@ class Client {
     );
 
     final Map<String, dynamic> headers = {
-      'content-type': "application/octet-stream",
+      'content-type': option?.contentType ?? "application/octet-stream",
       'content-length': multipartFile.length,
       'x-oss-forbid-overwrite': option.forbidOverride,
       'x-oss-object-acl': option.acl,

--- a/lib/src/request_option.dart
+++ b/lib/src/request_option.dart
@@ -8,6 +8,7 @@ class PutRequestOption {
   final AclMode? aclModel;
   final bool? override;
   final StorageType? storageType;
+  final String? contentType;
 
   const PutRequestOption({
     this.bucketName,
@@ -16,6 +17,7 @@ class PutRequestOption {
     this.aclModel,
     this.override,
     this.storageType,
+    this.contentType,
   });
 }
 


### PR DESCRIPTION
currently file content type will always be application/octet-stream
add content type field to PutRequestOption, so people can modify the content type according to the file

增加了可以自定义上传header的content-type，当前只能是application/octet-stream